### PR TITLE
edge-api: insecure proxy option

### DIFF
--- a/packages/constructs/edge-api/src/dev-edge-api.ts
+++ b/packages/constructs/edge-api/src/dev-edge-api.ts
@@ -75,8 +75,9 @@ export class DevEdgeAPI extends Construct {
     return Fn.join(replace, Fn.split(find, str))
   }
 
-  private ensureHTTPS(url: string) {
-    return `https://${this.replaceStr(this.replaceStr(url, 'http://', ''), 'https://', '')}`
+  private ensureHTTPS(url: string, insecure?: boolean) {
+    const protocol = insecure ? 'http' : 'https'
+    return `${protocol}://${this.replaceStr(this.replaceStr(url, 'http://', ''), 'https://', '')}`
   }
 
   private pickDestination(destination: Destination): string {
@@ -110,7 +111,7 @@ export class DevEdgeAPI extends Construct {
         path,
         integration: new HttpUrlIntegration(
           'proxy-integration',
-          this.ensureHTTPS(this.pickDestination(endpoint.destination)) + destPath,
+          this.ensureHTTPS(this.pickDestination(endpoint.destination), endpoint.insecure) + destPath,
         ),
         methods,
       })
@@ -119,7 +120,7 @@ export class DevEdgeAPI extends Construct {
           path: endpoint.pathPattern.replace('*', '{proxy+}'),
           integration: new HttpUrlIntegration(
             'proxy-integration',
-            this.ensureHTTPS(this.pickDestination(endpoint.destination)) + destPath + '/{proxy}',
+            this.ensureHTTPS(this.pickDestination(endpoint.destination), endpoint.insecure) + destPath + '/{proxy}',
           ),
           methods,
         })

--- a/packages/constructs/edge-api/src/types.ts
+++ b/packages/constructs/edge-api/src/types.ts
@@ -48,6 +48,7 @@ export interface ProxyEndpoint extends BaseEndpoint {
   disableBuiltInMiddlewares?: DisableBuiltInMiddlewares
   originResponseInterceptor?: EdgeAPILambda
   methods?: HttpMethod[]
+  insecure?: boolean
 }
 
 export interface RedirectionEndpoint extends BaseEndpoint {


### PR DESCRIPTION
Useful for manually adding proxies to s3 buckets, since these don't support https.