### PR TITLE
fix(prod edge-api): Apply the WAF web acl to the Distribution

### DIFF
--- a/packages/constructs/edge-api/src/production-edge-api.ts
+++ b/packages/constructs/edge-api/src/production-edge-api.ts
@@ -79,6 +79,7 @@ export class ProductionEdgeAPI extends Construct {
       }),
       domainNames: props.domains,
       certificate: props.certificate,
+      webAclId: props.webAclId
     })
     this.r53Target = RecordTarget.fromAlias(new CloudFrontTarget(distribution))
     new CloudfrontInvalidation(this, 'invalidation', {

--- a/packages/constructs/edge-api/tests/construct.test.ts
+++ b/packages/constructs/edge-api/tests/construct.test.ts
@@ -96,6 +96,15 @@ describe('edge-api', () => {
       expect(warnSpy).toHaveBeenCalledWith('devMode enabled, ignoring webAclId')
       warnSpy.mockRestore()
     })
+    test('webAclId prodMod', () => {
+      const warnSpy = jest.spyOn(global.console, 'warn')
+      synth('us-east-1', {
+        devMode: false,
+        webAclId: 'asdf',
+      })
+      expect(warnSpy).not.toHaveBeenCalledWith('devMode enabled, ignoring webAclId')
+      warnSpy.mockRestore()
+    })
     test('default endpoint', () => {
       const { template } = synth('us-east-1', {})
       const result = template()


### PR DESCRIPTION
Update to ensure the production edge API uses the given WAF web ACL when constructing the CloudFront Distro